### PR TITLE
Fix font texture building for Apple M1 devices

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -108,6 +108,7 @@ impl Renderer {
         // Font texture
         let fonts_texture = {
             let mut fonts = imgui.fonts();
+            fonts.tex_desired_width = 16384;
             let atlas_texture = fonts.build_rgba32_texture();
             let memory_properties = unsafe {
                 vk_context

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -119,7 +119,7 @@ impl Renderer {
             // Must be a power-of-two. If you have many glyphs and your graphics API has texture size
             // restrictions, you may want to increase texture width to decrease the height.
             // For example, Apple's Metal API (MTLTextureDescriptor) only supports
-            // max size of 16384 (128x128) for texture wdith/height on M1 devices.
+            // a maximum size of 16384 (128x128) for texture dimension on M1 devices.
             // We are defining the max width to be the max image dimension size get from device
             // properties here to be safe.
             fonts.tex_desired_width = device_properties.limits.max_image_dimension2_d as i32;

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -109,12 +109,20 @@ impl Renderer {
         let fonts_texture = {
             let mut fonts = imgui.fonts();
 
+            let device_properties = unsafe {
+                vk_context
+                     .instance()
+                     .get_physical_device_properties(vk_context.physical_device())
+             };
+
             // Texture width desired by user before building the atlas.
             // Must be a power-of-two. If you have many glyphs and your graphics API has texture size
             // restrictions, you may want to increase texture width to decrease the height.
-            // Apple's Metal API (MTLTextureDescriptor) only supports max size of 16384 (128x128).
-            // We are defining the max width to be 16384 here to support Apple devices.
-            fonts.tex_desired_width = 16384;
+            // For example, Apple's Metal API (MTLTextureDescriptor) only supports
+            // max size of 16384 (128x128) for texture wdith/height on M1 devices.
+            // We are defining the max width to be the max image dimension size get from device
+            // properties here to be safe.
+            fonts.tex_desired_width = device_properties.limits.max_image_dimension2_d as i32;
 
             let atlas_texture = fonts.build_rgba32_texture();
             let memory_properties = unsafe {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -108,7 +108,14 @@ impl Renderer {
         // Font texture
         let fonts_texture = {
             let mut fonts = imgui.fonts();
+
+            // Texture width desired by user before building the atlas.
+            // Must be a power-of-two. If you have many glyphs and your graphics API has texture size
+            // restrictions, you may want to increase texture width to decrease the height.
+            // Apple's Metal API (MTLTextureDescriptor) only supports max size of 16384 (128x128).
+            // We are defining the max width to be 16384 here to support Apple devices.
             fonts.tex_desired_width = 16384;
+
             let atlas_texture = fonts.build_rgba32_texture();
             let memory_properties = unsafe {
                 vk_context


### PR DESCRIPTION
Apple's Metal API (MTLTextureDescriptor) only supports a maximum size of 16384 (128x128) for texture width/height on M1 devices.
We are defining the max width to be the max image dimension size get from device properties here to be safe.

Reference: https://github.com/imgui-rs/imgui-rs/blob/b798342157fad17488d2fc5978ecf2a5f5d76c42/imgui/src/fonts/atlas.rs
API Doc: https://germangb.github.io/imgui-ext/imgui/struct.FontAtlas.html